### PR TITLE
gm_duesseldorf/KK123_20/01.xml: Fixes redundant xml:id value

### DIFF
--- a/xml/transcript/gm_duesseldorf/KK123_20/01.xml
+++ b/xml/transcript/gm_duesseldorf/KK123_20/01.xml
@@ -374,7 +374,7 @@
                     <seg f:left="#deln2">⏑</seg></line>
                 <line f:pos="between" xml:id="Strenget-Wickeln"><handShift new="#ri_bl_lat"/>Str<anchor xml:id="Stren"/>eng<anchor xml:id="get"/>et <anchor xml:id="in3"/>in k<anchor xml:id="koest"/>öſtliche W<anchor xml:id="Wik"/>ick<anchor xml:id="keln"/>eln –</line>
                 <line f:pos="over" xml:id="lf"><handShift new="#ri_t_lat"/>Str<anchor xml:id="Stren2"/>eng<anchor xml:id="get2"/>et <anchor xml:id="in4"/>in
-                        k<anchor xml:id="koest2"/>öſtl<anchor xml:id="li"/>ich<anchor xml:id="che"/>e W<anchor xml:id="Wik2"/>ick<anchor xml:id="keln2"/>eln</line>
+                        k<anchor xml:id="koest2"/>öſtl<anchor xml:id="li1"/>ich<anchor xml:id="che"/>e W<anchor xml:id="Wik2"/>ick<anchor xml:id="keln2"/>eln</line>
                 <line f:left="#Stren" f:pos="between" xml:id="lbk" type="inter"><handShift new="#ri_bl_lat"/>⎼ <seg f:left="#get">⏑</seg>
                     <seg f:left="#in3">⏑</seg>
                     <seg f:left="#koest">⎼</seg>
@@ -411,7 +411,7 @@
                     <seg f:left="#ben">⏑</seg>
                     <seg f:left="#Laenge"><handShift new="#ri_bl_lat"/><gap precision="medium" quantity="5" unit="chars"/></seg></line>
                 <line f:pos="between" xml:id="Kraeftig"><handShift new="#ri_bl_lat"/>Kr<anchor xml:id="Kraef"/>äftig <anchor xml:id="und3"/><unclear cert="high">und</unclear> z<anchor xml:id="zier3"/>ierlich <anchor xml:id="a"/>ab<anchor xml:id="ber"/>er</line>
-                <line f:pos="over" xml:id="li"><handShift new="#ri_t_lat"/>Kr<anchor xml:id="Kraef2"/>äft<anchor xml:id="tig2"/>ig <anchor xml:id="und4"/>und
+                <line f:pos="over" xml:id="li2"><handShift new="#ri_t_lat"/>Kr<anchor xml:id="Kraef2"/>äft<anchor xml:id="tig2"/>ig <anchor xml:id="und4"/>und
                         z<anchor xml:id="zier4"/>ierl<anchor xml:id="lich3"/>ich <anchor xml:id="a2"/>ab<anchor xml:id="ber2"/>er</line>
                 <line f:left="#Kraef" f:pos="between" xml:id="lbq" type="inter"><handShift new="#ri_bl_lat"/>⎼ <seg f:left="#und3">⏑</seg>
                     <seg f:left="#zier3">⎼</seg>


### PR DESCRIPTION
In an XML document a `xml:id`-value was used twice which isn't allowed in any of the XML specs.